### PR TITLE
feat: add new type of failure: `'CALLBACK_FAILED'`.

### DIFF
--- a/src/classes/ExtendedSchema.ts
+++ b/src/classes/ExtendedSchema.ts
@@ -5,6 +5,7 @@ import {
     ValidationRules,
 } from '../models/ExtendedSchemaTypes'
 import {
+    CALLBACK_FAILED,
     EXCESS_KEYS_INPUT,
     FailedValidation,
     INTERNAL_ERROR,
@@ -88,7 +89,7 @@ export class ExtendedSchema<ImpliedType> implements SchemaBlueprint<ImpliedType>
                     }
 
                     if (field.callback && !field.callback(valueToCheck)) {
-                        return WRONG_TYPE_INPUT('Callback failed. Key: ' + key)
+                        return CALLBACK_FAILED('Callback failed. Key: ' + key)
                     }
 
                     encounteredKeys.add(key)
@@ -123,7 +124,7 @@ export class ExtendedSchema<ImpliedType> implements SchemaBlueprint<ImpliedType>
                 }
 
                 if (field.callback && !field.callback(valueToCheck)) {
-                    return WRONG_TYPE_INPUT('Callback failed. Key: ' + key)
+                    return CALLBACK_FAILED('Callback failed. Key: ' + key)
                 }
 
                 encounteredKeys.add(key)

--- a/src/models/ValidationResults.ts
+++ b/src/models/ValidationResults.ts
@@ -3,7 +3,7 @@ export interface SuccessfulValidation<T = any> {
     value: T
 }
 
-type TypeOfFailure = 'WRONG_TYPE' | 'MISSING_KEYS' | 'EXCESS_KEYS' | 'INTERNAL_ERROR'
+type TypeOfFailure = 'WRONG_TYPE' | 'MISSING_KEYS' | 'EXCESS_KEYS' | 'INTERNAL_ERROR' | 'CALLBACK_FAILED'
 
 export interface FailedValidation {
     success: false
@@ -28,4 +28,7 @@ export const EXCESS_KEYS_INPUT = (message: string): FailedValidation => {
 }
 export const INTERNAL_ERROR = (message: string): FailedValidation => {
     return INVALID_INPUT('INTERNAL_ERROR', message)
+}
+export const CALLBACK_FAILED = (message: string): FailedValidation => {
+    return INVALID_INPUT('CALLBACK_FAILED', message)
 }


### PR DESCRIPTION
### Description of change

Add a new type of failure, which allows developers to better understand the type of failure. Specifically, add `'CALLBACK_FAILED'`, which triggers if callback is present has returned false.

### Pull-Request Checklist

- [✅] Code is up-to-date with the `main` branch
- [✅] `npm run lint` passes with this change
- [✅] `npm run test` passes with this change
- [N/A] This pull request links relevant issues as `Fixes #0000`
- [❌] There are new or updated unit tests validating the change
- [✅] Documentation has been updated to reflect this change
- [✅] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

