### PR TITLE
FEATURE: Add support for null type and methods to get user-friendly schema representation.

### DIFF
--- a/src/classes/ExtendedSchema.ts
+++ b/src/classes/ExtendedSchema.ts
@@ -192,7 +192,7 @@ export class ExtendedSchema<ImpliedType> implements SchemaBlueprint<ImpliedType>
                 if (displayedAs) {
                     result[fieldKey] = displayedAs
                 } else {
-                    let keyTypes = typesToCheck.join('| ')
+                    let keyTypes = typesToCheck.join(' | ')
                     if (callback) {
                         keyTypes += ' (callback)'
                     }

--- a/src/classes/ExtendedSchema.ts
+++ b/src/classes/ExtendedSchema.ts
@@ -106,6 +106,9 @@ export class ExtendedSchema<ImpliedType> implements SchemaBlueprint<ImpliedType>
                         // because typeof [] === 'object'
                         continue
                     }
+                    if (typeToCheck === 'null' && valueToCheck === null) {
+                        continue
+                    }
                     if (typeToCheck === 'extSchema' && valueIsObject(valueToCheck)) {
                         if (!('schema' in field) || field?.schema === undefined) {
                             return INTERNAL_ERROR('Schema is not defined for key: ' + key)

--- a/src/classes/ExtendedSchema.ts
+++ b/src/classes/ExtendedSchema.ts
@@ -1,7 +1,7 @@
 import {
     NestedSchemaField,
     SchemaBlueprint,
-    SchemaFieldDefinition,
+    SchemaFieldDefinition, SupportedTypes,
     ValidationRules,
 } from '../models/ExtendedSchemaTypes'
 import {
@@ -230,17 +230,10 @@ export class ExtendedSchema<ImpliedType> implements SchemaBlueprint<ImpliedType>
         })
     }
 
-    public addNumberOrNullField(key: string, options?: addFieldOptions<number | null>): void {
+    public addNullableField(key: string, otherTypes: Omit<SupportedTypes[], 'null'>, options?: addFieldOptions<any>): void {
         this.addField(key, {
             ...options,
-            typesToCheck: ['number', 'null'],
-        })
-    }
-
-    public addStringOrNullField(key: string, options?: addFieldOptions<string | null>): void {
-        this.addField(key, {
-            ...options,
-            typesToCheck: ['string', 'null'],
+            typesToCheck: [...otherTypes, 'null'],
         })
     }
 

--- a/src/classes/Schema.ts
+++ b/src/classes/Schema.ts
@@ -78,7 +78,12 @@ export class Schema<T extends SchemaDefinition> implements SchemaBlueprint<T> {
                 if (!Array.isArray(value)) {
                     return WRONG_TYPE_INPUT('Type mismatch. Expected array, got ' + typeof value)
                 }
-            } else if (typeof value !== expectedType) {
+            } else if (expectedType === 'null') {
+                if (value !== null) {
+                    return WRONG_TYPE_INPUT('Type mismatch. Expected null, got ' + typeof value)
+                }
+            }
+            else if (typeof value !== expectedType) {
                 return WRONG_TYPE_INPUT('Type mismatch. Expected ' + expectedType + ', got ' + typeof value)
             }
             return VALID_INPUT(value as TypeMapping[T])

--- a/src/classes/Schema.ts
+++ b/src/classes/Schema.ts
@@ -95,4 +95,8 @@ export class Schema<T extends SchemaDefinition> implements SchemaBlueprint<T> {
     public length(): number {
         return Object.keys(this.schema).length
     }
+
+    public toJSON(): Record<string, unknown> {
+        return this.schema
+    }
 }

--- a/src/models/ExtendedSchemaTypes.ts
+++ b/src/models/ExtendedSchemaTypes.ts
@@ -8,6 +8,7 @@ export interface SchemaFieldDefinition {
     typesToCheck: Array<SupportedTypes>
     callback?: SchemaCallback
     undefined?: 'allow' | 'forbid'
+    displayedAs?: string
 }
 
 export interface NestedSchemaField {
@@ -19,10 +20,9 @@ export interface NestedSchemaField {
 
 export interface SchemaBlueprint<ImpliedType> {
     addField(key: string, type: SchemaFieldDefinition): void
-
     check(value: any): SuccessfulValidation<ImpliedType> | FailedValidation
-
     length(): number
+    toJSON(): Record<string, unknown>
 }
 
 type EXCESS_ALLOW_FLAGS = 'keep' | 'clean' | 'forbid'

--- a/src/models/ExtendedSchemaTypes.ts
+++ b/src/models/ExtendedSchemaTypes.ts
@@ -1,6 +1,6 @@
 import { FailedValidation, SuccessfulValidation } from './ValidationResults'
 
-type SupportedTypes = 'string' | 'number' | 'boolean' | 'object' | 'array' | 'null'
+export type SupportedTypes = 'string' | 'number' | 'boolean' | 'object' | 'array' | 'null'
 
 type SchemaCallback = (value: any) => boolean | [boolean, string]
 

--- a/src/models/ExtendedSchemaTypes.ts
+++ b/src/models/ExtendedSchemaTypes.ts
@@ -1,6 +1,6 @@
 import { FailedValidation, SuccessfulValidation } from './ValidationResults'
 
-type SupportedTypes = 'string' | 'number' | 'boolean' | 'object' | 'array'
+type SupportedTypes = 'string' | 'number' | 'boolean' | 'object' | 'array' | 'null'
 
 export interface SchemaFieldDefinition {
     typesToCheck: Array<SupportedTypes>

--- a/src/models/ExtendedSchemaTypes.ts
+++ b/src/models/ExtendedSchemaTypes.ts
@@ -2,15 +2,17 @@ import { FailedValidation, SuccessfulValidation } from './ValidationResults'
 
 type SupportedTypes = 'string' | 'number' | 'boolean' | 'object' | 'array' | 'null'
 
+type SchemaCallback = (value: any) => boolean | [boolean, string]
+
 export interface SchemaFieldDefinition {
     typesToCheck: Array<SupportedTypes>
-    callback?: (value: any) => boolean
+    callback?: SchemaCallback
     undefined?: 'allow' | 'forbid'
 }
 
 export interface NestedSchemaField {
     typesToCheck: ['extSchema']
-    callback?: (value: any) => boolean
+    callback?: SchemaCallback
     undefined?: 'allow' | 'forbid'
     schema: SchemaBlueprint<any>
 }

--- a/src/models/SchemaTypes.ts
+++ b/src/models/SchemaTypes.ts
@@ -23,6 +23,7 @@ export type Input<T extends SchemaDefinition> = {
 export type SchemaBlueprint<T extends SchemaDefinition> = {
     check(value: Input<T>): FailedValidation | SuccessfulValidation<{ [K in keyof T]: TypeMapping[T[K]] }>
     length(): number
+    toJSON(): Record<string, unknown>
 }
 
 type EXCESS_ALLOW_FLAGS = 'keep' | 'clean' | 'forbid'

--- a/src/models/SchemaTypes.ts
+++ b/src/models/SchemaTypes.ts
@@ -1,6 +1,6 @@
 import { FailedValidation, SuccessfulValidation } from './ValidationResults'
 
-export type SupportedTypes = 'string' | 'number' | 'boolean' | 'object' | 'array' | 'any'
+export type SupportedTypes = 'string' | 'number' | 'boolean' | 'object' | 'array' | 'null' | 'any'
 
 export type TypeMapping = {
     string: string
@@ -8,6 +8,7 @@ export type TypeMapping = {
     boolean: boolean
     object: Record<string, unknown>
     array: any[]
+    null: null
     any: any
 }
 

--- a/test/ExtendedSchema.spec.ts
+++ b/test/ExtendedSchema.spec.ts
@@ -31,7 +31,9 @@ describe('Extended Schema', () => {
         schema.addStringField('name')
         schema.addNumberField('age')
         schema.addEmailField('email')
-        schema.addRegexField('phone', /^(\([0-9]{3}\) |[0-9]{3}-)[0-9]{3}-[0-9]{4}$/gm)
+        schema.addRegexField('phone', /^(\([0-9]{3}\) |[0-9]{3}-)[0-9]{3}-[0-9]{4}$/gm, {
+            displayedAs: 'US phone number',
+        })
         const addressSchema = new ExtendedSchema<{ notifications: boolean; theme: string }>()
         addressSchema.addBooleanField('notifications')
         addressSchema.addStringField('theme')
@@ -81,6 +83,17 @@ describe('Extended Schema', () => {
             success: true,
             value: objectToCheck,
         } as SuccessfulValidation<TestSchemaInterface>)
+        expect(schema.length()).toBe(8)
+        expect(schema.toJSON()).toEqual({
+            name: 'string',
+            age: 'number',
+            email: 'email',
+            phone: 'US phone number',
+            address: { notifications: 'boolean', theme: 'string' },
+            groups: 'array (callback)',
+            friends: 'array<{"name":"string","age":"number"}>',
+            'isMale?': 'false',
+        })
     })
 
     test('Schema cleans excess keys on rule', () => {

--- a/test/ExtendedSchema.spec.ts
+++ b/test/ExtendedSchema.spec.ts
@@ -37,8 +37,8 @@ describe('Extended Schema', () => {
         schema.addRegexField('phone', /^(\([0-9]{3}\) |[0-9]{3}-)[0-9]{3}-[0-9]{4}$/gm, {
             displayedAs: 'US phone number',
         })
-        schema.addNumberOrNullField('children')
-        schema.addStringOrNullField('jobTitle')
+        schema.addNullableField('children', ['number'])
+        schema.addNullableField('jobTitle', ['string'])
 
         const addressSchema = new ExtendedSchema<{ notifications: boolean; theme: string }>()
         addressSchema.addBooleanField('notifications')

--- a/test/ExtendedSchema.spec.ts
+++ b/test/ExtendedSchema.spec.ts
@@ -5,6 +5,8 @@ interface TestSchemaInterface {
     email: string
     age: number
     phone: string
+    children: number | null
+    jobTitle: string | null
 
     address: {
         notifications: boolean
@@ -16,6 +18,7 @@ interface TestSchemaInterface {
         age: number
     }[]
     isMale?: boolean
+    reserved: null
 }
 
 /*
@@ -34,6 +37,9 @@ describe('Extended Schema', () => {
         schema.addRegexField('phone', /^(\([0-9]{3}\) |[0-9]{3}-)[0-9]{3}-[0-9]{4}$/gm, {
             displayedAs: 'US phone number',
         })
+        schema.addNumberOrNullField('children')
+        schema.addStringOrNullField('jobTitle')
+
         const addressSchema = new ExtendedSchema<{ notifications: boolean; theme: string }>()
         addressSchema.addBooleanField('notifications')
         addressSchema.addStringField('theme')
@@ -54,12 +60,15 @@ describe('Extended Schema', () => {
             callback: value => true,
             undefined: 'allow',
         })
+        schema.addNullField('reserved')
 
         const objectToCheck = {
             name: 'John',
             email: 'fakeemail@gmail.com',
             age: 30,
             phone: '123-456-7890',
+            children: null,
+            jobTitle: null,
             address: {
                 notifications: true,
                 theme: 'dark',
@@ -75,6 +84,7 @@ describe('Extended Schema', () => {
                     age: 35,
                 },
             ],
+            reserved: null,
         }
 
         const result = schema.check(objectToCheck)
@@ -83,16 +93,19 @@ describe('Extended Schema', () => {
             success: true,
             value: objectToCheck,
         } as SuccessfulValidation<TestSchemaInterface>)
-        expect(schema.length()).toBe(8)
+        expect(schema.length()).toBe(11)
         expect(schema.toJSON()).toEqual({
             name: 'string',
             age: 'number',
             email: 'email',
+            children: 'number | null',
+            jobTitle: 'string | null',
             phone: 'US phone number',
             address: { notifications: 'boolean', theme: 'string' },
             groups: 'array (callback)',
             friends: 'array<{"name":"string","age":"number"}>',
             'isMale?': 'false',
+            reserved: 'null',
         })
     })
 

--- a/test/Schema.spec.ts
+++ b/test/Schema.spec.ts
@@ -64,4 +64,12 @@ describe('Schema', () => {
         const result = NameAgeSchema.check(input)
         expect(result).toHaveProperty('success', false)
     })
+
+    test('Schema toJSON() return valid object', () => {
+        const result = NameAgeSchema.toJSON()
+        expect(result).toEqual({
+            name: 'string',
+            age: 'number',
+        })
+    })
 })


### PR DESCRIPTION
### Description of change

Add support for `null` type in both schema types as well as sugar-methods for "only null" and "null or other types" fields. Add `toJson` methods to both schemas, allowing developers to return JSON-like representation of schemas (useful if you want to include expected schema in your bad request response). Fixed issue with `ExtendedSchema`, when it would fail validation for fields with more than 1 type of possible values. 

### Pull-Request Checklist

- [✅] Code is up-to-date with the `main` branch
- [✅] `npm run lint` passes with this change
- [✅] `npm run test` passes with this change
- [N/A] This pull request links relevant issues as `Fixes #0000`
- [✅] There are new or updated unit tests validating the change
- [✅] Documentation has been updated to reflect this change
- [✅] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)
